### PR TITLE
rpc: Implement runtime PoW algo switching

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -170,6 +170,7 @@ const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* 
     return pa;
 }
 
+// Veles
 std::string GetAlgoName(int32_t nAlgo)
 {
     switch (nAlgo)
@@ -192,6 +193,7 @@ std::string GetAlgoName(int32_t nAlgo)
 
 int32_t GetAlgoId(std::string strAlgo)
 {
+    //transform(strAlgo.begin(), strAlgo.end(), strAlgo.begin(), ::tolower);
     if (strAlgo == "sha256d")         return ALGO_SHA256D;
     if (strAlgo == "scrypt")          return ALGO_SCRYPT;
     if (strAlgo == "nist5")           return ALGO_NIST5;
@@ -199,5 +201,6 @@ int32_t GetAlgoId(std::string strAlgo)
     if (strAlgo == "x11")             return ALGO_X11;
     if (strAlgo == "x16r")            return ALGO_X16R;
 
-    return miningAlgo;
+    return ALGO_NULL;
 }
+//

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1262,27 +1262,13 @@ bool AppInitParameterInteraction()
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
     }
 
-    // FXTC BEGIN
-    // algo switch
-    // VELES BEGIN
-    std::string strAlgo = gArgs.GetArg("-algo", DEFAULT_MINING_ALGO);
-    // VELES END
-    transform(strAlgo.begin(), strAlgo.end(), strAlgo.begin(), ::tolower);
-    if (strAlgo == "sha256d")
-         miningAlgo = ALGO_SHA256D;
-    else if (strAlgo == "scrypt")
-         miningAlgo = ALGO_SCRYPT;
-    else if (strAlgo == "nist5")
-         miningAlgo = ALGO_NIST5;
-    else if (strAlgo == "lyra2z")
-         miningAlgo = ALGO_LYRA2Z;
-    else if (strAlgo == "x11")
-         miningAlgo = ALGO_X11;
-    else if (strAlgo == "x16r")
-         miningAlgo = ALGO_X16R;
-    else
-         miningAlgo = ALGO_SHA256D; // FXTC TODO: we should not be here
-    // FXTC END
+    // Veles
+    miningAlgo = GetAlgoId(gArgs.GetArg("-algo", DEFAULT_MINING_ALGO));
+    if (miningAlgo == ALGO_NULL)
+        return InitError("unknown PoW mining algo requested.");
+
+     LogPrintf("Setting current PoW algorithm to %s\n", GetAlgoName(miningAlgo));
+    //
 
     return true;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -148,7 +148,7 @@ void BlockAssembler::resetBlock()
 Optional<int64_t> BlockAssembler::m_last_block_num_txs{nullopt};
 Optional<int64_t> BlockAssembler::m_last_block_weight{nullopt};
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, int32_t nPowAlgo) // Veles: Add parameter nPowAlgo
 {
     int64_t nTimeStart = GetTimeMicros();
 
@@ -170,7 +170,13 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;
 
-    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
+    // Veles
+    if (nPowAlgo == ALGO_NULL)
+        pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
+    else
+        pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), nPowAlgo);
+    //
+
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (chainparams.MineBlocksOnDemand())
@@ -260,6 +266,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     return std::move(pblocktemplate);
 }
+// Veles
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
+{
+    return BlockAssembler::CreateNewBlock(scriptPubKeyIn, ALGO_NULL);
+}
+//
 
 void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
 {

--- a/src/miner.h
+++ b/src/miner.h
@@ -160,8 +160,11 @@ public:
     BlockAssembler(const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, int32_t nPowAlgo); // VELES: Add parameter nPowAlgo
+    // VELES BEGIN
+    /** Default behaviour to return block for the algo set in the daemon configuration */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);
-
+    // VELES END
     static Optional<int64_t> m_last_block_num_txs;
     static Optional<int64_t> m_last_block_weight;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2164,7 +2164,7 @@ void ThreadScriptCheck() {
 
 VersionBitsCache versionbitscache GUARDED_BY(cs_main);
 
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, int32_t nPowAlgo) // VELES: Add parameter nPowAlgo
 {
     if (pindexPrev->nHeight+1 < sporkManager.GetSporkValue(SPORK_VELES_01_FXTC_CHAIN_START)) return 4;
 
@@ -2178,11 +2178,18 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         }
     }
 
-    // encode algo into nVersion
-    nVersion |= miningAlgo;
+    // VELES: Encode algo into nVersion
+    nVersion |= nPowAlgo;
 
     return nVersion;
 }
+
+// VELES BEGIN
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+{
+  return ComputeBlockVersion(pindexPrev, params, miningAlgo);
+}
+// VELES END
 
 bool GetBlockHash(uint256& hashRet, int nBlockHeight)
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -556,7 +556,13 @@ bool GetBlockHash(uint256& hashRet, int nBlockHeight = -1);
 /**
  * Determine what nVersion a new block should use.
  */
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, int32_t nPowAlgo); // VELES: Add parameter nPowAlgo
+// VELES BEGIN
+/**
+ * Default behaviour is to return block version for the algo set in the configuration
+ */
 int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+// VELES END
 
 /** Reject codes greater or equal to this can be returned by AcceptToMemPool
  * for transactions, to signal internal conditions. They cannot and should not


### PR DESCRIPTION
Allow RPC methods such as getblocktemplate or getmininginfo to accept the preferred PoW algorithm name as a parameter without the need to restart the wallet or to run multiple wallets.