### PR TITLE
Fix block index unnecessary memory consumption

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -204,12 +204,7 @@ public:
 
     // FXTC BEGIN
     //! (memory only) Total amount of work normalized to algorithm efficiency
-    arith_uint256 nChainWorkSha256d;
-    arith_uint256 nChainWorkScrypt;
-    arith_uint256 nChainWorkNist5;
-    arith_uint256 nChainWorkLyra2Z;
-    arith_uint256 nChainWorkX11;
-    arith_uint256 nChainWorkX16R;
+    arith_uint256 nChainWorkAlgo;
     // FXTC END
 
     //! Number of transactions in this block.
@@ -248,12 +243,7 @@ public:
         nUndoPos = 0;
         nChainWork = arith_uint256();
         // FXTC BEGIN
-        nChainWorkSha256d = arith_uint256();
-        nChainWorkScrypt = arith_uint256();
-        nChainWorkNist5 = arith_uint256();
-        nChainWorkLyra2Z = arith_uint256();
-        nChainWorkX11 = arith_uint256();
-        nChainWorkX16R = arith_uint256();
+        nChainWorkAlgo = arith_uint256();
         // FXTC END
         nTx = 0;
         nChainTx = 0;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -78,30 +78,11 @@ static UniValue GetNetworkHashPS(int lookup, int height, int32_t nAlgo) {   // V
 
     arith_uint256 workDiff = pb->nChainWork - pb0->nChainWork;
     // FXTC BEGIN
-    switch (nAlgo)
-    {
-        case ALGO_SHA256D:
-            workDiff = pb->nChainWorkSha256d - pb0->nChainWorkSha256d;
-            break;
-        case ALGO_SCRYPT:
-            // VELES BEGIN
-            if (pb->nChainWorkScrypt > 0)
-            // VELES END
-            workDiff = pb->nChainWorkScrypt - pb0->nChainWorkScrypt;
-            break;
-        case ALGO_NIST5:
-            workDiff = pb->nChainWorkNist5 - pb0->nChainWorkNist5;
-            break;
-        case ALGO_LYRA2Z:
-            workDiff = pb->nChainWorkLyra2Z - pb0->nChainWorkLyra2Z;
-            break;
-        case ALGO_X11:
-            workDiff = pb->nChainWorkX11 - pb0->nChainWorkX11;
-            break;
-        case ALGO_X16R:
-            workDiff = pb->nChainWorkX16R - pb0->nChainWorkX16R;
-            break;
-    }
+    CBlockIndex* pbAlgo = pb;
+    while (pbAlgo->pprev && nAlgo != (pbAlgo->nVersion & ALGO_VERSION_MASK)) pbAlgo = pbAlgo->pprev;
+    CBlockIndex* pb0Algo = pb0;
+    while (pb0Algo->pprev && nAlgo != (pb0Algo->nVersion & ALGO_VERSION_MASK)) pb0Algo = pb0Algo->pprev;
+    workDiff = pbAlgo->nChainWorkAlgo - pb0Algo->nChainWorkAlgo;
     // FXTC END
     int64_t timeDiff = maxTime - minTime;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3551,12 +3551,11 @@ CBlockIndex* CChainState::AddToBlockIndex(const CBlockHeader& block)
     pindexNew->nTimeMax = (pindexNew->pprev ? std::max(pindexNew->pprev->nTimeMax, pindexNew->nTime) : pindexNew->nTime);
     pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
     // FXTC BEGIN
-    pindexNew->nChainWorkSha256d = (pindexNew->pprev ? pindexNew->pprev->nChainWorkSha256d : 0) + (((pindexNew->nVersion & ALGO_VERSION_MASK) == ALGO_SHA256D) ? GetBlockProof(*pindexNew) : 0);
-    pindexNew->nChainWorkScrypt = (pindexNew->pprev ? pindexNew->pprev->nChainWorkScrypt : 0) + (((pindexNew->nVersion & ALGO_VERSION_MASK) == ALGO_SCRYPT) ? GetBlockProof(*pindexNew) : 0);
-    pindexNew->nChainWorkNist5 = (pindexNew->pprev ? pindexNew->pprev->nChainWorkNist5 : 0) + (((pindexNew->nVersion & ALGO_VERSION_MASK) == ALGO_NIST5) ? GetBlockProof(*pindexNew) : 0);
-    pindexNew->nChainWorkLyra2Z = (pindexNew->pprev ? pindexNew->pprev->nChainWorkLyra2Z : 0) + (((pindexNew->nVersion & ALGO_VERSION_MASK) == ALGO_LYRA2Z) ? GetBlockProof(*pindexNew) : 0);
-    pindexNew->nChainWorkX11 = (pindexNew->pprev ? pindexNew->pprev->nChainWorkX11 : 0) + (((pindexNew->nVersion & ALGO_VERSION_MASK) == ALGO_X11) ? GetBlockProof(*pindexNew) : 0);
-    pindexNew->nChainWorkX16R = (pindexNew->pprev ? pindexNew->pprev->nChainWorkX16R : 0) + (((pindexNew->nVersion & ALGO_VERSION_MASK) == ALGO_X16R) ? GetBlockProof(*pindexNew) : 0);
+    int32_t nAlgo = pindexNew->nVersion & ALGO_VERSION_MASK;
+    CBlockIndex* pindexNewAlgo = pindexNew;
+    if (pindexNewAlgo->pprev) pindexNewAlgo = pindexNewAlgo->pprev;
+    while (pindexNewAlgo->pprev && nAlgo != (pindexNewAlgo->nVersion & ALGO_VERSION_MASK)) pindexNewAlgo = pindexNewAlgo->pprev;
+    pindexNew->nChainWorkAlgo = (pindexNewAlgo ? pindexNewAlgo->nChainWorkAlgo : 0) + GetBlockProof(*pindexNew);
     // FXTC END
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == nullptr || pindexBestHeader->nChainWork < pindexNew->nChainWork)
@@ -4497,12 +4496,11 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
         CBlockIndex* pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         // FXTC BEGIN
-        pindex->nChainWorkSha256d = (pindex->pprev ? pindex->pprev->nChainWorkSha256d : 0) + (((pindex->nVersion & ALGO_VERSION_MASK) == ALGO_SHA256D) ? GetBlockProof(*pindex) : 0);
-        pindex->nChainWorkScrypt = (pindex->pprev ? pindex->pprev->nChainWorkScrypt : 0) + (((pindex->nVersion & ALGO_VERSION_MASK) == ALGO_SCRYPT) ? GetBlockProof(*pindex) : 0);
-        pindex->nChainWorkNist5 = (pindex->pprev ? pindex->pprev->nChainWorkNist5 : 0) + (((pindex->nVersion & ALGO_VERSION_MASK) == ALGO_NIST5) ? GetBlockProof(*pindex) : 0);
-        pindex->nChainWorkLyra2Z = (pindex->pprev ? pindex->pprev->nChainWorkLyra2Z : 0) + (((pindex->nVersion & ALGO_VERSION_MASK) == ALGO_LYRA2Z) ? GetBlockProof(*pindex) : 0);
-        pindex->nChainWorkX11 = (pindex->pprev ? pindex->pprev->nChainWorkX11 : 0) + (((pindex->nVersion & ALGO_VERSION_MASK) == ALGO_X11) ? GetBlockProof(*pindex) : 0);
-        pindex->nChainWorkX16R = (pindex->pprev ? pindex->pprev->nChainWorkX16R : 0) + (((pindex->nVersion & ALGO_VERSION_MASK) == ALGO_X16R) ? GetBlockProof(*pindex) : 0);
+        int32_t nAlgo = pindex->nVersion & ALGO_VERSION_MASK;
+        CBlockIndex* pindexAlgo = pindex;
+        if (pindexAlgo->pprev) pindexAlgo = pindexAlgo->pprev;
+        while (pindexAlgo->pprev && nAlgo != (pindexAlgo->nVersion & ALGO_VERSION_MASK)) pindexAlgo = pindexAlgo->pprev;
+        pindex->nChainWorkAlgo = (pindexAlgo ? pindexAlgo->nChainWorkAlgo : 0) + GetBlockProof(*pindex);
         // FXTC END
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);
         // We can link the chain of blocks for which we've received transactions at some point.


### PR DESCRIPTION
Block index store single algo chainwork instead of all algos for every block.

Before optimization: 950.6 MB
After optimization: 570.8 MB
```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
34895 uhlik     20   0 5819.3m 950.6m 212.4m S   0.3  0.9   0:45.16 build/fxtc/src/qt/fxtc-qt
 2654 uhlik     20   0 5479.3m 570.8m 194.3m S   0.3  0.6   0:27.97 build/fxtc-development/src/qt/fxtc-qt
```